### PR TITLE
add link to Packet Events page

### DIFF
--- a/events/available-events/README.md
+++ b/events/available-events/README.md
@@ -30,6 +30,10 @@ Remember all `@Subscribe` event methods must not be static!
 [hudrenderevent.md](hudrenderevent.md)
 {% endcontent-ref %}
 
+{% content-ref url="packet-events.md" %}
+[packet-events.md](packet-events.md)
+{% endcontent-ref %}
+
 {% content-ref url="locrawevent.md" %}
 [locrawevent.md](locrawevent.md)
 {% endcontent-ref %}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
It shows up on sidebar but it was forgotten in the available events page

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15 (yes this is almost a year later dont ask me why i didnt do this back then)

## How to test
<!-- Provide steps to test this PR -->
open the page

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
+ Add link to Packet Events
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->