### PR TITLE
change send packet event description + code

### DIFF
--- a/events/available-events/packet-events.md
+++ b/events/available-events/packet-events.md
@@ -18,11 +18,11 @@ This event is cancellable, meaning you can stop the packet from getting into the
 @Subscribe
 public void onPacketSend(SendPacketEvent event) {
     // check if the packet is the right type
-    if(event.packet instanceof S0FPacketSpawnMob) {
+    if(event.packet instanceof C14PacketTabComplete) {
         // cast the packet to the right type
-        S0FPacketSpawnMob packet = (S0FPacketSpawnMob) event.packet;
+        C14PacketTabComplete packet = (C14PacketTabComplete) event.packet;
         // do something with it
-        System.out.println("Entity attempted to be spawned with ID: " + packet.getEntityID());
+        System.out.println("Attempted to send a tab complete packet with message:" + packet.getMessage());
         // cancel the event afterwards, rendering this packet useless.
         event.isCancelled = true;
     }

--- a/events/available-events/packet-events.md
+++ b/events/available-events/packet-events.md
@@ -11,7 +11,7 @@ SendPacketEvent is (as the name suggests) an event that is fired every time the 
 This event also gets the packet that is going to be sent, as a `Packet<?>`. You can use code like the code below to do things with it.
 
 {% hint style="warning" %}
-This event is cancellable, meaning you can stop the packet from getting into the games code. Be careful with what you cancel!
+This event is cancellable, meaning you can stop the packet from being sent to the server. Be careful with what you cancel!
 {% endhint %}
 
 ```java


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
changes the description of the send packet event to match sending a packet instead of receiving one, uses the client tab completion packet instead of the server spawn mob packet
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #
none
## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
no